### PR TITLE
Remove remove the `format!(..)` macro call from panic!

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,5 +39,5 @@ fn main() {
     }
     let argv: Vec<String> = from_str(&args[2]).expect("That's not a JSON-array of strings");
     execv_stringvec(&argv); // on the happy path execution of this program will stop here
-    panic!(format!("Exec failed: {}", argv[0]));
+    panic!("Exec failed: {}", argv[0]);
 }


### PR DESCRIPTION
Eliminating the following:

warning: panic message is not a string literal
  --> src/main.rs:42:12
   |
42 |     panic!(format!("Exec failed: {}", argv[0]));
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(non_fmt_panics)]` on by default
   = note: this usage of panic!() is deprecated; it will be a hard error in Rust 2021
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
   = note: the panic!() macro supports formatting, so there's no need for the format!() macro here
help: remove the `format!(..)` macro call
